### PR TITLE
Fixed warnings on Carthage installation.

### DIFF
--- a/RESideMenu.xcodeproj/project.pbxproj
+++ b/RESideMenu.xcodeproj/project.pbxproj
@@ -372,10 +372,6 @@
 		9D08DAF31B0C72A100EA8198 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -389,10 +385,6 @@
 		9D08DAF41B0C72A100EA8198 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = RESideMenuTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Upon installation of the framework through Carthage using your fork warnings arose. 

```
Building scheme "RESideMenu" in RESideMenu.xcodeproj
ld: warning: directory not found for option '-F/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/Developer/Library/Frameworks'
ld: warning: directory not found for option '-F/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.3.sdk/Developer/Library/Frameworks'
```

Fixed them in this PR.
